### PR TITLE
[BE/docs] dev브랜치 pr merge시 깃헙액션으로 바로 이슈까지 닫히도록 설정

### DIFF
--- a/.github/auto-close-issues.yml
+++ b/.github/auto-close-issues.yml
@@ -1,0 +1,51 @@
+name: Auto Close Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    
+    steps:
+      - name: Close issues from PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const commitMsg = context.payload.pull_request.merge_commit_message || '';
+            const text = `${prBody}\n${commitMsg}`;
+            
+            // close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved 키워드로 이슈 번호 찾기
+            const issueRegex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+            const matches = [...text.matchAll(issueRegex)];
+            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1])))];
+            
+            if (issueNumbers.length === 0) {
+              console.log('No issues found to close');
+              return;
+            }
+            
+            console.log(`Found issues to close: ${issueNumbers.join(', ')}`);
+            
+            for (const issueNumber of issueNumbers) {
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed'
+                });
+                console.log(`Closed issue #${issueNumber}`);
+              } catch (error) {
+                console.log(`Failed to close issue #${issueNumber}: ${error.message}`);
+              }
+            }
+


### PR DESCRIPTION
# 🔀 Pull Request
<!-- PR 제목 컨벤션 -> [BE/feat] pr 제목 -->

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [x] Docs (문서 작업)


## 📝 개요(Summary)

<!-- 이번 PR이 어떤 작업인지 간단히 설명해주세요. -->
dev브랜치에 PR을 올릴경우,
base 브랜치가 dev일 경우  이 PR이 머지 되면서 닫힐 때
PR description 또는 merge commit 메시지 안에서
closes #이슈번호(비슷한 다른형태 포함) 형태가 발견되다면
-> 그 즉시 GitHub Actions가 실행 → 해당 issue 닫힘
