### PR TITLE
[BE/fix] 공연 상세 조회 스케줄 날짜 조회 오류 수정

### DIFF
--- a/src/main/java/back/kalender/domain/performance/schedule/repository/PerformanceScheduleRepository.java
+++ b/src/main/java/back/kalender/domain/performance/schedule/repository/PerformanceScheduleRepository.java
@@ -13,6 +13,16 @@ public interface PerformanceScheduleRepository extends JpaRepository<Performance
     // 특정 공연의 모든 회차 조회
     List<PerformanceSchedule> findAllByPerformanceIdOrderByPerformanceDateAscStartTimeAsc(Long performanceId);
 
+    // 특정 공연의 예매 가능한 날짜 목록 조회 (중복 제거)
+    @Query("""
+        select distinct ps.performanceDate
+        from PerformanceSchedule ps
+        where ps.performanceId = :performanceId
+        order by ps.performanceDate asc
+    """)
+    List<LocalDate> findAvailableDatesByPerformanceId(@Param("performanceId") Long performanceId);
+
+
     // 특정 공연의 특정 날짜 회차들만 조회
     List<PerformanceSchedule> findAllByPerformanceIdAndPerformanceDateOrderByStartTimeAsc(
         Long performanceId,
@@ -20,7 +30,4 @@ public interface PerformanceScheduleRepository extends JpaRepository<Performance
     );
 
     List<PerformanceSchedule> findByPerformanceId(Long performanceId);
-
-    // 특정 공연의 예매 가능한 날짜 목록 조회 (중복 제거)
-    List<LocalDate> findAvailableDatesByPerformanceId(Long performanceId);
 }


### PR DESCRIPTION
# 🔀 Pull Request
[BE/fix] 공연 상세 조회 스케줄 날짜 조회 오류 수정

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #102 

## 📝 개요(Summary)
공연 상세 조회 API에서 스케줄 날짜 조회 시 발생하던 타입 변환 오류를 수정했습니다.

## 🔧 코드 설명 & 변경 이유(Code Description)
- PerformanceSchedule 조회 시 엔티티를 LocalDate로 직접 매핑하려다 발생하던 변환 오류를 수정했습니다.
- JPQL에서 날짜 컬럼만 선택하도록 쿼리를 명시하여 타입 불일치를 해결했습니다.

## 🧪 테스트 절차(Test Plan)
- Postman으로 공연 상세 조회 API 정상 응답(200 OK) 확인
- Swagger Authorize 후 Try it out 정상 동작 확인

## 👀 리뷰 포인트(Notes for Reviewer)

