### PR TITLE
[BE/feat] 강퇴알림, 기념일 알림 추가

### DIFF
--- a/src/main/java/back/kalender/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/back/kalender/domain/notification/scheduler/NotificationScheduler.java
@@ -62,11 +62,11 @@ public class NotificationScheduler {
         String content;
         String url = "/party/" + target.partyId();
 
-        if (target.category() == ScheduleCategory.BIRTHDAY) {
-            content = String.format("오늘은 [%s]입니다. 다함께 축하해주세요! 🎂", target.scheduleTitle());
+        if (target.category() == ScheduleCategory.BIRTHDAY || target.category() == ScheduleCategory.ANNIVERSARY) {
+            content = String.format("오늘은 %s입니다. 다함께 축하해주세요! 🎂", target.scheduleTitle());
         } else {
             String timeStr = target.scheduleTime().format(DateTimeFormatter.ofPattern("HH시 mm분"));
-            content = String.format("오늘 %s에 [%s] 일정이 있습니다!", timeStr, target.scheduleTitle());
+            content = String.format("오늘 %s에 %s 일정이 있습니다!", timeStr, target.scheduleTitle());
         }
 
         notificationService.send(

--- a/src/test/java/back/kalender/domain/notification/schedular/NotificationSchedulerTest.java
+++ b/src/test/java/back/kalender/domain/notification/schedular/NotificationSchedulerTest.java
@@ -1,0 +1,94 @@
+package back.kalender.domain.notification.scheduler;
+
+import back.kalender.domain.notification.enums.NotificationType;
+import back.kalender.domain.notification.service.NotificationService;
+import back.kalender.domain.party.dto.query.NotificationTarget;
+import back.kalender.domain.party.repository.PartyRepository;
+import back.kalender.domain.schedule.enums.ScheduleCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+
+    @InjectMocks
+    private NotificationScheduler notificationScheduler;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private PartyRepository partyRepository;
+
+    @Test
+    @DisplayName("카테고리별(생일, 기념일, 일반)로 알림 메시지가 다르게 발송되어야 한다")
+    void sendScheduledNotifications_ShouldSendDifferentMessagesByCategory() {
+        LocalDateTime fixedTime = LocalDateTime.of(2024, 12, 25, 0, 0);
+
+        NotificationTarget birthdayTarget = new NotificationTarget(
+                1L, 100L, "지민 생일", ScheduleCategory.BIRTHDAY, fixedTime
+        );
+
+        NotificationTarget anniversaryTarget = new NotificationTarget(
+                2L, 200L, "데뷔 10주년", ScheduleCategory.ANNIVERSARY, fixedTime
+        );
+
+        NotificationTarget concertTarget = new NotificationTarget(
+                3L, 300L, "흠뻑쇼", ScheduleCategory.CONCERT, fixedTime
+        );
+
+        given(partyRepository.findNotificationTargets(any(), any()))
+                .willReturn(List.of(birthdayTarget, anniversaryTarget, concertTarget));
+
+        notificationScheduler.sendScheduledNotifications();
+
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.EVENT_REMINDER),
+                anyString(),
+                eq("오늘은 지민 생일입니다. 다함께 축하해주세요! 🎂"),
+                contains("/party/100")
+        );
+
+        verify(notificationService).send(
+                eq(2L),
+                eq(NotificationType.EVENT_REMINDER),
+                anyString(),
+                eq("오늘은 데뷔 10주년입니다. 다함께 축하해주세요! 🎂"),
+                contains("/party/200")
+        );
+
+        verify(notificationService).send(
+                eq(3L),
+                eq(NotificationType.EVENT_REMINDER),
+                anyString(),
+                eq("오늘 00시 00분에 흠뻑쇼 일정이 있습니다!"),
+                contains("/party/300")
+        );
+
+        verify(notificationService, times(3)).send(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("알림 대상이 없으면 서비스 호출 없이 종료되어야 한다")
+    void sendScheduledNotifications_WhenNoTargets_ShouldNotCallService() {
+        given(partyRepository.findNotificationTargets(any(), any()))
+                .willReturn(List.of());
+
+        notificationScheduler.sendScheduledNotifications();
+
+        verify(notificationService, times(0)).send(any(), any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
# 🔀 Pull Request
<!-- PR 제목 컨벤션 -> [BE/feat] pr 제목 -->
[BE/feat] 강퇴알림, 기념일 알림 추가

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #119 


## 📝 개요(Summary)

<!-- 이번 PR이 어떤 작업인지 간단히 설명해주세요. -->
강퇴 멤버에게 
```java
Title: 파티에서 강퇴되었습니다.
Content: "\"%s\" 파티에서 강퇴되었습니다. 참여자들을 평가해주세요."

```
라는 알림이 발송됩니다.


## 🔧 코드 설명 & 변경 이유(Code Description)

<!-- 어떤 코드를 작성/수정했는지, 왜 이런 방식으로 구현했는지 -->
- `ChatService`에 강퇴 알림이 구현되어있으며, 
- 기존에 생일만 축하해줬었는데 이번에는 ANNIVERSARY 도 추가해두었습니다.

## 🧪 테스트 절차(Test Plan)

<!--※ 테스트가 필요한 경우에만 작성 -->
- `ChatService` 로 강퇴 알림 테스트해봤는데 승범님 PR이랑 충돌날 거 같아서 테스트 통과하는 것만 확인하고 이번 PR에는 포함시키지 않았습니다.
- `NotificationSchedulerTest`에서 카테고리별로 알림이 제대로 발송되는지 테스트했습니다.
  - 성공: 알림 대상이 없으면 서비스 호출 없이 종료되어야 한다
  - 성공: 카테고리별(생일, 기념일, 일반)로 알림 메시지가 다르게 발송되어야 한다

