### PR TITLE
[BE/feat] 프로필 이미지 s3 presign으로 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     implementation 'org.webjars:stomp-websocket:2.3.4'
 
     implementation 'org.redisson:redisson:3.24.3'
+
+    implementation platform("software.amazon.awssdk:bom:2.25.60")
+    implementation "software.amazon.awssdk:s3"
 }
 
 tasks.named('test') {

--- a/src/main/java/back/kalender/domain/user/controller/UserController.java
+++ b/src/main/java/back/kalender/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package back.kalender.domain.user.controller;
 
+import back.kalender.domain.user.dto.request.CompleteProfileImageRequest;
 import back.kalender.domain.user.dto.request.UpdateProfileRequest;
 import back.kalender.domain.user.dto.request.UserSignupRequest;
+import back.kalender.domain.user.dto.response.PresignProfileImageResponse;
 import back.kalender.domain.user.dto.response.UploadProfileImgResponse;
 import back.kalender.domain.user.dto.response.UserProfileResponse;
 import back.kalender.domain.user.dto.response.UserSignupResponse;
@@ -30,7 +32,6 @@ public class UserController implements UserControllerSpec {
         return ResponseEntity.ok(response);
     }
 
-
     @GetMapping("/me")
     @Override
     public ResponseEntity<UserProfileResponse> getMyProfile(
@@ -39,19 +40,6 @@ public class UserController implements UserControllerSpec {
         Long userId = userDetails.getUserId();
 
         UserProfileResponse response = userService.getMyProfile(userId);
-        return ResponseEntity.ok(response);
-    }
-
-
-    @PostMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Override
-    public ResponseEntity<UploadProfileImgResponse> uploadProfileImage(
-            @RequestParam("profile_image") MultipartFile profileImage,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Long userId = userDetails.getUserId();
-
-        UploadProfileImgResponse response = userService.uploadProfileImage(userId, profileImage);
         return ResponseEntity.ok(response);
     }
 
@@ -68,4 +56,28 @@ public class UserController implements UserControllerSpec {
         UserProfileResponse response = userService.updateMyProfile(userId, request);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/me/profile-image/presign")
+    @Override
+    public ResponseEntity<PresignProfileImageResponse> presignProfileImage(
+            @RequestParam("contentType") String contentType,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        PresignProfileImageResponse response = userService.presignProfileImageUpload(userId, contentType);
+        return ResponseEntity.ok(response);
+    }
+
+    // 업로드 완료: key 저장 + presigned GET URL 반환
+    @PostMapping("/me/profile-image/complete")
+    @Override
+    public ResponseEntity<UploadProfileImgResponse> completeProfileImage(
+            @RequestBody CompleteProfileImageRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        UploadProfileImgResponse response = userService.completeProfileImageUpload(userId, request.Key());
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/back/kalender/domain/user/controller/UserControllerSpec.java
+++ b/src/main/java/back/kalender/domain/user/controller/UserControllerSpec.java
@@ -1,7 +1,9 @@
 package back.kalender.domain.user.controller;
 
+import back.kalender.domain.user.dto.request.CompleteProfileImageRequest;
 import back.kalender.domain.user.dto.request.UpdateProfileRequest;
 import back.kalender.domain.user.dto.request.UserSignupRequest;
+import back.kalender.domain.user.dto.response.PresignProfileImageResponse;
 import back.kalender.domain.user.dto.response.UploadProfileImgResponse;
 import back.kalender.domain.user.dto.response.UserProfileResponse;
 import back.kalender.domain.user.dto.response.UserSignupResponse;
@@ -154,58 +156,6 @@ public interface UserControllerSpec {
     );
 
     @Operation(
-            summary = "프로필 이미지 업로드",
-            description = "사용자의 프로필 이미지를 업로드합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "업로드 성공",
-                    content = @Content(schema = @Schema(implementation = UploadProfileImgResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 파일",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                        {
-                                          "error": {
-                                            "code": "BAD_REQUEST",
-                                            "status": "400",
-                                            "message": "잘못된 요청입니다."
-                                          }
-                                        }
-                                        """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                        {
-                                          "error": {
-                                            "code": "UNAUTHORIZED",
-                                            "status": "401",
-                                            "message": "로그인이 필요합니다."
-                                          }
-                                        }
-                                        """
-                            )
-                    )
-            )
-    })
-    ResponseEntity<UploadProfileImgResponse> uploadProfileImage(
-            @RequestParam("profile_image") MultipartFile profileImage,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    );
-
-    @Operation(
             summary = "내 정보 수정",
             description = "사용자의 닉네임, 프로필 이미지를 수정합니다."
     )
@@ -272,6 +222,58 @@ public interface UserControllerSpec {
     })
     ResponseEntity<UserProfileResponse> updateMyProfile(
             @RequestBody UpdateProfileRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "프로필 이미지 업로드 presigned PUT 발급",
+            description = "S3에 직접 업로드할 수 있는 presigned PUT URL을 발급합니다. contentType은 PUT 요청의 Content-Type과 반드시 동일해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "발급 성공",
+                    content = @Content(schema = @Schema(implementation = PresignProfileImageResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    ResponseEntity<PresignProfileImageResponse> presignProfileImage(
+            @RequestParam("contentType") String contentType,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "프로필 이미지 업로드 완료 처리",
+            description = "클라이언트가 presigned PUT으로 S3 업로드를 완료한 뒤, 서버에 key를 저장합니다. 등록/수정 동일 API로 처리됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "완료 처리 성공",
+                    content = @Content(schema = @Schema(implementation = UploadProfileImgResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 key 또는 요청",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    ResponseEntity<UploadProfileImgResponse> completeProfileImage(
+            @RequestBody CompleteProfileImageRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/back/kalender/domain/user/dto/request/CompleteProfileImageRequest.java
+++ b/src/main/java/back/kalender/domain/user/dto/request/CompleteProfileImageRequest.java
@@ -1,0 +1,9 @@
+package back.kalender.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 이미지 업로드 완료 요청")
+public record CompleteProfileImageRequest(
+        String Key
+) {
+}

--- a/src/main/java/back/kalender/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/back/kalender/domain/user/dto/request/UpdateProfileRequest.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "사용자 정보 수정 요청")
 public record UpdateProfileRequest (
-        String nickname,
-        String profileImage
+        String nickname
 ){
 }

--- a/src/main/java/back/kalender/domain/user/dto/response/PresignProfileImageResponse.java
+++ b/src/main/java/back/kalender/domain/user/dto/response/PresignProfileImageResponse.java
@@ -1,0 +1,13 @@
+package back.kalender.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "프로필 이미지 presigned PUT 발급 응답")
+public record PresignProfileImageResponse(
+        String key,
+        String uploadUrl,
+        Map<String, String> requiredHeaders,
+        long expiresInSeconds
+) {}

--- a/src/main/java/back/kalender/domain/user/dto/response/UploadProfileImgResponse.java
+++ b/src/main/java/back/kalender/domain/user/dto/response/UploadProfileImgResponse.java
@@ -2,7 +2,7 @@ package back.kalender.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "프로필 이미지 업로드 응답")
+@Schema(description = "프로필 이미지 업로드 완료 응답")
 public record UploadProfileImgResponse (
         String profileImageUrl
 ) {}

--- a/src/main/java/back/kalender/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/back/kalender/domain/user/dto/response/UserProfileResponse.java
@@ -13,11 +13,11 @@ public record UserProfileResponse(
         Integer age,
         Gender gender
 ) {
-    public static UserProfileResponse from(User user) {
+    public static UserProfileResponse from(User user, String profileImageUrl) {
         return new UserProfileResponse(
                 user.getEmail(),
                 user.getNickname(),
-                user.getProfileImage(),
+                profileImageUrl,
                 user.getLevel(),
                 user.getAge(),
                 user.getGender()

--- a/src/main/java/back/kalender/domain/user/entity/User.java
+++ b/src/main/java/back/kalender/domain/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Column(name = "profile_image")
-    private String profileImage;
+    private String profileImage; // S3 Object Key 저장
 
     private Gender gender;
 
@@ -44,8 +44,8 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void updateProfileImage(String profileImage) {
-        this.profileImage = profileImage;
+    public void updateProfileImage(String profileImageKey) {
+        this.profileImage = profileImageKey;
     }
 
     public void updatePassword(String password) {

--- a/src/main/java/back/kalender/domain/user/service/S3PresignService.java
+++ b/src/main/java/back/kalender/domain/user/service/S3PresignService.java
@@ -1,0 +1,72 @@
+package back.kalender.domain.user.service;
+
+import back.kalender.domain.user.dto.response.PresignProfileImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3PresignService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.profile-prefix:profile/}")
+    private String profilePrefix;
+
+    @Value("${aws.s3.presign-expire-minutes:10}")
+    private long presignExpireMinutes;
+
+    public PresignProfileImageResponse presignProfileImagePut(Long userId, String contentType) {
+        String key = profilePrefix + userId + "/" + UUID.randomUUID();
+
+        PutObjectRequest putReq = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(presignExpireMinutes))
+                .putObjectRequest(putReq)
+                .build();
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignReq);
+
+        return new PresignProfileImageResponse(
+                key,
+                presigned.url().toString(),
+                Map.of("Content-Type", contentType),
+                presignExpireMinutes * 60
+        );
+    }
+
+    public String presignProfileImageGet(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        GetObjectRequest getReq = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignReq = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(presignExpireMinutes))
+                .getObjectRequest(getReq)
+                .build();
+
+        return s3Presigner.presignGetObject(presignReq).url().toString();
+    }
+}

--- a/src/main/java/back/kalender/global/config/S3Config.java
+++ b/src/main/java/back/kalender/global/config/S3Config.java
@@ -1,0 +1,21 @@
+package back.kalender.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,3 +86,9 @@ custom:
     redisson:
       address: ${REDISSON_ADDRESS:redis://${spring.data.redis.host}:${spring.data.redis.port}}
       password: ${REDIS_PASSWORD:}
+aws:
+  s3:
+    bucket: wya-kalendar-profile-images-v1
+    region: ap-northeast-2
+    profile-prefix: profile/
+    presign-expire-minutes: 10

--- a/src/test/java/back/kalender/domain/user/service/UserServiceTest.java
+++ b/src/test/java/back/kalender/domain/user/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package back.kalender.domain.user.service;
 
 import back.kalender.domain.user.dto.request.UpdateProfileRequest;
+import back.kalender.domain.user.dto.response.PresignProfileImageResponse;
 import back.kalender.domain.user.dto.response.UploadProfileImgResponse;
 import back.kalender.domain.user.dto.response.UserProfileResponse;
 import back.kalender.domain.user.entity.User;
@@ -14,23 +15,27 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 테스트")
 public class UserServiceTest {
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private S3PresignService s3PresignService;
 
     @InjectMocks
     private UserService userService;
@@ -43,11 +48,14 @@ public class UserServiceTest {
                 .email("test@example.com")
                 .password("password123")
                 .nickname("테스트유저")
+                .profileImage("profile/1/uuid")
                 .gender(Gender.FEMALE)
                 .birthDate(LocalDate.of(2000, 1, 1))
                 .build();
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(s3PresignService.presignProfileImageGet("profile/1/uuid"))
+                .thenReturn("https://presigned-get-url");
 
         UserProfileResponse response = userService.getMyProfile(userId);
 
@@ -56,8 +64,35 @@ public class UserServiceTest {
         assertThat(response.nickname()).isEqualTo("테스트유저");
         assertThat(response.gender()).isEqualTo(Gender.FEMALE);
         assertThat(response.age()).isEqualTo(25); // 2025 - 2000 = 25
+        assertThat(response.profileImage()).isEqualTo("https://presigned-get-url");
 
         verify(userRepository, times(1)).findById(userId);
+        verify(s3PresignService, times(1)).presignProfileImageGet("profile/1/uuid");
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 프로필 이미지가 null이면 profileImageUrl도 null")
+    void getMyProfile_ProfileImageNull() {
+        Long userId = 1L;
+        User mockUser = User.builder()
+                .email("test@example.com")
+                .password("password123")
+                .nickname("테스트유저")
+                .profileImage(null)
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(s3PresignService.presignProfileImageGet(null)).thenReturn(null);
+
+        UserProfileResponse response = userService.getMyProfile(userId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.profileImage()).isNull();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(s3PresignService, times(1)).presignProfileImageGet(null);
     }
 
     @Test
@@ -71,152 +106,157 @@ public class UserServiceTest {
                 .hasMessageContaining("유저를 찾을 수 없습니다");
 
         verify(userRepository, times(1)).findById(userId);
+        verifyNoInteractions(s3PresignService);
     }
 
     @Test
-    @DisplayName("프로필 이미지 업로드 - 성공")
-    void uploadProfileImage_Success() {
+    @DisplayName("프로필 이미지 presign PUT 발급 - 성공")
+    void presignProfileImageUpload_Success() {
         Long userId = 1L;
-        MockMultipartFile mockFile = new MockMultipartFile(
-                "file",
-                "test.jpg",
-                "image/jpeg",
-                "test image content".getBytes()
-        );
+        String contentType = "image/jpeg";
+
+        PresignProfileImageResponse mockResponse =
+                new PresignProfileImageResponse(
+                        "profile/1/uuid",
+                        "https://presigned-put-url",
+                        Map.of("Content-Type", contentType),
+                        600
+                );
+
+        when(s3PresignService.presignProfileImagePut(userId, contentType))
+                .thenReturn(mockResponse);
+
+        PresignProfileImageResponse response = userService.presignProfileImageUpload(userId, contentType);
+
+        assertThat(response).isNotNull();
+        assertThat(response.key()).isEqualTo("profile/1/uuid");
+        assertThat(response.uploadUrl()).isEqualTo("https://presigned-put-url");
+        assertThat(response.requiredHeaders()).containsEntry("Content-Type", contentType);
+
+        verify(s3PresignService, times(1)).presignProfileImagePut(userId, contentType);
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 presign PUT 발급 - contentType이 비어있으면 실패")
+    void presignProfileImageUpload_BadRequest() {
+        Long userId = 1L;
+
+        assertThatThrownBy(() -> userService.presignProfileImageUpload(userId, ""))
+                .isInstanceOf(ServiceException.class);
+
+        verifyNoInteractions(s3PresignService);
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 완료(complete) - 성공 (key 저장 + presigned GET URL 반환)")
+    void completeProfileImageUpload_Success() {
+        Long userId = 1L;
 
         User mockUser = User.builder()
                 .email("test@example.com")
                 .password("password123")
                 .nickname("테스트유저")
+                .profileImage(null)
                 .gender(Gender.FEMALE)
                 .birthDate(LocalDate.of(2000, 1, 1))
                 .build();
+        setUserId(mockUser, userId);
 
+        String key = "profile/1/uuid";
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(s3PresignService.presignProfileImageGet(key)).thenReturn("https://presigned-get-url");
 
-        UploadProfileImgResponse response = userService.uploadProfileImage(userId, mockFile);
+        UploadProfileImgResponse response = userService.completeProfileImageUpload(userId, key);
 
         assertThat(response).isNotNull();
-        assertThat(response.profileImageUrl()).contains("https://s3.amazonaws.com/kalender/profile/");
+        assertThat(response.profileImageUrl()).isEqualTo("https://presigned-get-url");
+        assertThat(mockUser.getProfileImage()).isEqualTo(key); // ✅ key 저장 확인
 
         verify(userRepository, times(1)).findById(userId);
+        verify(s3PresignService, times(1)).presignProfileImageGet(key);
     }
 
     @Test
-    @DisplayName("프로필 이미지 업로드 - 유저를 찾을 수 없음")
-    void uploadProfileImage_UserNotFound() {
-        Long userId = 999L;
-        MockMultipartFile mockFile = new MockMultipartFile(
-                "file",
-                "test.jpg",
-                "image/jpeg",
-                "test image content".getBytes()
-        );
+    @DisplayName("프로필 이미지 업로드 완료(complete) - key prefix가 profile/{userId}/가 아니면 실패")
+    void completeProfileImageUpload_InvalidKeyPrefix_Fail() {
+        Long userId = 1L;
 
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        User mockUser = User.builder()
+                .email("test@example.com")
+                .password("password123")
+                .nickname("테스트유저")
+                .build();
+        setUserId(mockUser, userId);
 
-        assertThatThrownBy(() -> userService.uploadProfileImage(userId, mockFile))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("유저를 찾을 수 없습니다");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        String invalidKey = "profile/999/uuid"; // userId mismatch
+
+        assertThatThrownBy(() -> userService.completeProfileImageUpload(userId, invalidKey))
+                .isInstanceOf(ServiceException.class);
 
         verify(userRepository, times(1)).findById(userId);
+        verifyNoMoreInteractions(userRepository);
+        verifyNoInteractions(s3PresignService);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 완료(complete) - 유저를 찾을 수 없음")
+    void completeProfileImageUpload_UserNotFound() {
+        Long userId = 999L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.completeProfileImageUpload(userId, "profile/999/uuid"))
+                .isInstanceOf(ServiceException.class);
+
+        verify(userRepository, times(1)).findById(userId);
+        verifyNoInteractions(s3PresignService);
     }
 
     @Test
     @DisplayName("내 정보 수정 - 닉네임만 수정 성공")
     void updateMyProfile_OnlyNickname_Success() {
         Long userId = 1L;
-        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임", null);
+        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
 
         User mockUser = User.builder()
                 .email("test@example.com")
                 .password("password123")
                 .nickname("기존닉네임")
+                .profileImage("profile/1/old")
                 .gender(Gender.FEMALE)
                 .birthDate(LocalDate.of(2000, 1, 1))
                 .build();
+        setUserId(mockUser, userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(userRepository.findByNickname("새닉네임")).thenReturn(Optional.empty());
+        when(s3PresignService.presignProfileImageGet("profile/1/old"))
+                .thenReturn("https://presigned-get-url-old");
 
         UserProfileResponse response = userService.updateMyProfile(userId, request);
 
         assertThat(response).isNotNull();
         assertThat(response.nickname()).isEqualTo("새닉네임");
+        assertThat(response.profileImage()).isEqualTo("https://presigned-get-url-old");
 
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).findByNickname("새닉네임");
-    }
-
-    @Test
-    @DisplayName("내 정보 수정 - 프로필 이미지만 수정 성공")
-    void updateMyProfile_OnlyProfileImage_Success() {
-        Long userId = 1L;
-        String newImageUrl = "https://new-image-url.com/profile.jpg";
-        UpdateProfileRequest request = new UpdateProfileRequest(null, newImageUrl);
-
-        User mockUser = User.builder()
-                .email("test@example.com")
-                .password("password123")
-                .nickname("테스트유저")
-                .profileImage("https://old-image-url.com/profile.jpg")
-                .gender(Gender.FEMALE)
-                .birthDate(LocalDate.of(2000, 1, 1))
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-        UserProfileResponse response = userService.updateMyProfile(userId, request);
-
-        assertThat(response).isNotNull();
-        assertThat(response.profileImage()).isEqualTo(newImageUrl);
-
-        verify(userRepository, times(1)).findById(userId);
-        verify(userRepository, never()).findByNickname(any());
-    }
-
-    @Test
-    @DisplayName("내 정보 수정 - 닉네임과 프로필 이미지 모두 수정 성공")
-    void updateMyProfile_BothFields_Success() {
-        Long userId = 1L;
-        String newNickname = "새닉네임";
-        String newImageUrl = "https://new-image-url.com/profile.jpg";
-        UpdateProfileRequest request = new UpdateProfileRequest(newNickname, newImageUrl);
-
-        User mockUser = User.builder()
-                .email("test@example.com")
-                .password("password123")
-                .nickname("기존닉네임")
-                .profileImage("https://old-image-url.com/profile.jpg")
-                .gender(Gender.FEMALE)
-                .birthDate(LocalDate.of(2000, 1, 1))
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        when(userRepository.findByNickname(newNickname)).thenReturn(Optional.empty());
-
-        UserProfileResponse response = userService.updateMyProfile(userId, request);
-
-        assertThat(response).isNotNull();
-        assertThat(response.nickname()).isEqualTo(newNickname);
-        assertThat(response.profileImage()).isEqualTo(newImageUrl);
-
-        verify(userRepository, times(1)).findById(userId);
-        verify(userRepository, times(1)).findByNickname(newNickname);
+        verify(s3PresignService, times(1)).presignProfileImageGet("profile/1/old");
     }
 
     @Test
     @DisplayName("내 정보 수정 - 닉네임 중복으로 실패")
     void updateMyProfile_DuplicateNickname_Fail() {
         Long userId = 1L;
-        UpdateProfileRequest request = new UpdateProfileRequest("중복닉네임", null);
+        UpdateProfileRequest request = new UpdateProfileRequest("중복닉네임");
 
         User currentUser = User.builder()
                 .email("test@example.com")
                 .password("password123")
                 .nickname("기존닉네임")
-                .gender(Gender.FEMALE)
-                .birthDate(LocalDate.of(2000, 1, 1))
                 .build();
         setUserId(currentUser, 1L);
 
@@ -224,8 +264,6 @@ public class UserServiceTest {
                 .email("other@example.com")
                 .password("password123")
                 .nickname("중복닉네임")
-                .gender(Gender.MALE)
-                .birthDate(LocalDate.of(1995, 5, 15))
                 .build();
         setUserId(otherUser, 2L);
 
@@ -233,27 +271,27 @@ public class UserServiceTest {
         when(userRepository.findByNickname("중복닉네임")).thenReturn(Optional.of(otherUser));
 
         assertThatThrownBy(() -> userService.updateMyProfile(userId, request))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("이미 사용 중인 닉네임입니다");
+                .isInstanceOf(ServiceException.class);
 
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).findByNickname("중복닉네임");
+        verifyNoInteractions(s3PresignService);
     }
 
     @Test
     @DisplayName("내 정보 수정 - 유저를 찾을 수 없음")
     void updateMyProfile_UserNotFound() {
         Long userId = 999L;
-        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임", null);
+        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
 
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.updateMyProfile(userId, request))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("유저를 찾을 수 없습니다");
+                .isInstanceOf(ServiceException.class);
 
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, never()).findByNickname(any());
+        verifyNoInteractions(s3PresignService);
     }
 
     private void setUserId(User user, Long id) {


### PR DESCRIPTION
# 🔀 Pull Request
[BE/feat] 프로필 이미지 s3 presign으로 처리

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #135 

## 📝 개요(Summary)
마이페이지 프로필 이미지 업로드를 AWS S3 Presigned URL 방식으로 전환했습니다.
서버를 통한 파일 업로드를 제거하고, 클라이언트가 S3에 직접 업로드하도록 구조를 개선했습니다.

## 🔧 코드 설명 & 변경 이유(Code Description)
- 프로필 이미지 업로드 방식을 Multipart → Presigned URL 방식으로 변경했습니다.
- 서버는 Presigned PUT / GET URL 생성 및 검증 역할만 담당하도록 책임을 분리했습니다.
- DB에는 이미지 URL이 아닌 S3 object key만 저장하고, 조회 시마다 Presigned GET URL을 생성해 반환합니다.
- 이를 통해 서버 부하 감소, 대용량 파일 처리 안정성, 보안(버킷 비공개 유지)을 함께 확보했습니다.


## 🧪 테스트 절차(Test Plan)
- Presigned PUT URL 발급 API 정상 동작 확인

## 🔄 API 변경 / 흐름 영향(API & Flow Impact)
**기존**

POST /users/me/profile-image

**변경**

1. GET /users/me/profile-image/presign
Presigned PUT URL + object key 발급

2. 클라이언트가 S3에 직접 PUT 업로드

3. POST /users/me/profile-image/complete
업로드된 key를 서버에 전달하여 프로필 이미지 갱신

4. /users/me 조회 시 Presigned GET URL 반환

기존 업로드 API는 Presigned 방식으로 대체됩니다.


## 👀 리뷰 포인트(Notes for Reviewer)
- 서버에서 presign 발급이 EC2 IAM Role 기준이라 로컬에서 S3 PUT 테스트가 어려워 
먼저 배포 후에 FE님이 테스트 해보시고 문제 생기면 추가 수정하려고 합니다.