### PR TITLE
[BE/refactor] 좌석 조회 Entity 기반 조회 방식 비교 및 캐시 동작 검증

### DIFF
--- a/src/main/java/back/kalender/domain/booking/performanceSeat/repository/PerformanceSeatRepository.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/repository/PerformanceSeatRepository.java
@@ -31,6 +31,7 @@ where p.scheduleId = :scheduleId
             @Param("scheduleId") Long scheduleId
     );
 
+    List<PerformanceSeat> findAllByScheduleId(Long scheduleId);
 
     Optional<PerformanceSeat> findByIdAndScheduleId(Long id, Long scheduleId);
 

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/service/PerformanceSeatQueryService.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/service/PerformanceSeatQueryService.java
@@ -23,11 +23,14 @@ public class PerformanceSeatQueryService {
     )
     @Transactional(readOnly = true)
     public List<PerformanceSeatResponse> getSeatsByScheduleId(
-            Long scheduleId,
-            String bookingSessionId
+        Long scheduleId,
+        String bookingSessionId
     ) {
-        queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
+    queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
 
-        return performanceSeatRepository.findSeatResponses(scheduleId);
+    return performanceSeatRepository.findAllByScheduleId(scheduleId)
+            .stream()
+            .map(PerformanceSeatResponse::from)
+            .toList();
     }
 }

--- a/src/main/java/back/kalender/domain/booking/waitingRoom/controller/QueueController.java
+++ b/src/main/java/back/kalender/domain/booking/waitingRoom/controller/QueueController.java
@@ -34,10 +34,10 @@ public class QueueController implements QueueControllerSpec {
     }
 
     @PostMapping("/ping/{scheduleId}")
-    public void ping(
+    public void waitingPing(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-BOOKING-SESSION-ID") String bookingSessionId
+            @RequestHeader("X-QSID") String qsid
     ) {
-        queueAccessService.ping(scheduleId, bookingSessionId);
+        queueService.waitingPing(scheduleId, qsid);
     }
 }

--- a/src/main/java/back/kalender/domain/booking/waitingRoom/service/ActiveSweepScheduler.java
+++ b/src/main/java/back/kalender/domain/booking/waitingRoom/service/ActiveSweepScheduler.java
@@ -3,7 +3,6 @@ package back.kalender.domain.booking.waitingRoom.service;
 import back.kalender.domain.performance.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +12,7 @@ public class ActiveSweepScheduler {
     private final RedisTemplate<String, String> redisTemplate;
     private final ScheduleQueryService scheduleQueryService;
 
-    @Scheduled(fixedDelay = 5000)
+    //@Scheduled(fixedDelay = 5000)
     public void sweep() {
         long cutoff = System.currentTimeMillis() - 60_000;
 

--- a/src/main/java/back/kalender/domain/booking/waitingRoom/service/QueueAccessService.java
+++ b/src/main/java/back/kalender/domain/booking/waitingRoom/service/QueueAccessService.java
@@ -4,9 +4,7 @@ import back.kalender.global.exception.ErrorCode;
 import back.kalender.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -27,14 +25,4 @@ public class QueueAccessService {
         }
     }
 
-    public void ping(Long scheduleId, String bookingSessionId) {
-        String key = activeKey(scheduleId);
-
-        Double score = redisTemplate.opsForZSet().score(key, bookingSessionId);
-        if (score == null) {
-            throw new ServiceException(ErrorCode.INVALID_BOOKING_SESSION);
-        }
-
-        redisTemplate.opsForZSet().add(key, bookingSessionId, System.currentTimeMillis());
-    }
 }

--- a/src/main/java/back/kalender/global/security/SecurityConfig.java
+++ b/src/main/java/back/kalender/global/security/SecurityConfig.java
@@ -114,8 +114,6 @@ public class SecurityConfig {
                 "/v3/api-docs/**",                 // OpenAPI 문서
                 "/swagger-resources/**",            // Swagger 리소스
                 "/api/v1/notifications/**",          // 알림
-                "/api/v1/performance-seats/**",
-                "/api/v1/queue/**",
                 "/ws-chat/**",                     // WebSocket 연결 허용
                 "/payment-test.html",               // 결제 테스트 페이지
                 "/payment/**",                      // 결제 관련 정적 파일

--- a/src/main/java/back/kalender/infra/redis/RedisCacheConfig.java
+++ b/src/main/java/back/kalender/infra/redis/RedisCacheConfig.java
@@ -1,11 +1,17 @@
 package back.kalender.infra.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
 import java.time.Duration;
 
@@ -18,12 +24,19 @@ public class RedisCacheConfig {
 
         RedisCacheConfiguration defaultConfig =
                 RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair
+                                        .fromSerializer(RedisSerializer.json())
+                        )
                         .entryTtl(Duration.ofMinutes(30))
                         .disableCachingNullValues();
 
-        // openSchedules 전용 캐시
         RedisCacheConfiguration openScheduleConfig =
                 RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair
+                                        .fromSerializer(RedisSerializer.json())
+                        )
                         .entryTtl(Duration.ofSeconds(10))
                         .disableCachingNullValues();
 


### PR DESCRIPTION
# 🔀 Pull Request
[BE/refactor] 좌석 조회 Entity 기반 조회 방식 비교 및 캐시 동작 검증

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

---

## 🍗 관련 이슈

- close #164 번호 (해당 없음)

---

## 📝 개요(Summary)

공연 좌석 조회 API에서  
**DTO 직접 조회 방식과 Entity 조회 후 DTO 변환 방식의 성능 차이를 비교**하고,  
Redis 캐시 적용 시 실제 캐시 hit 여부 및 응답 시간 특성을 검증했습니다.

---

## 🔧 코드 설명 & 변경 이유(Code Description)

- `PerformanceSeatRepository`에 **Entity 조회용 메서드**(`findAllByScheduleId`)를 추가하여  
  기존 DTO 직접 조회 방식과 비교 가능하도록 분리했습니다.
- `PerformanceSeatQueryService`에서
  - DTO 직접 조회 방식
  - Entity 조회 후 DTO 변환 방식  
  두 가지 구현을 분리하여 테스트했습니다.
- Redis 캐시(`seatLayout`)를 적용한 상태에서
  - Spring Cache TRACE 로그를 통해 cache hit 여부를 확인
  - cache hit 이후에도 약 0.2초의 응답 시간이 발생하는 원인을 분석했습니다.
- 분석 결과, DB 조회가 아닌  
  **대용량 좌석 데이터(약 15,000건)의 JSON 직렬화 및 HTTP 응답 전송 비용이 주요 원인**임을 확인했습니다.

→ 성능 차이가 거의 없는 상황에서는  
**유지보수성과 도메인 일관성을 고려해 Entity 기반 조회 방식도 충분히 합리적**하다고 판단했습니다.

---

## 🧪 테스트 절차(Test Plan)

1. Redis 캐시 OFF 상태에서
   - DTO 직접 조회 API 호출
   - Entity 조회 → DTO 변환 API 호출
   - Postman으로 응답 시간 비교
2. Redis 캐시 ON 상태에서
   - 동일한 `scheduleId`로 반복 호출
   - Spring Cache TRACE 로그로 cache hit 여부 확인
3. cache hit 이후에도 발생하는 응답 시간(≈0.2s)의 원인 분석

---

## 🔄 API 변경 / 흐름 영향(API & Flow Impact)

- **외부 API 스펙 변경 없음**
- 테스트를 위한 내부 조회 방식 분리만 수행
- 기존 좌석 조회 API 흐름에는 영향 없음

---

## 👀 리뷰 포인트(Notes for Reviewer)

- DTO 직접 조회 방식과 Entity 기반 조회 방식의 성능 차이가  
  실제 서비스 레벨에서 무시 가능한 수준이라는 결론이 타당한지 확인 부탁드립니다.
- Redis 캐시 hit 이후 병목을  
  “대용량 JSON 직렬화 비용”으로 해석한 부분에 대한 의견을 부탁드립니다.