### PR TITLE
[BE/feat] 비회원 아티스트 기반 스케줄 조회 API 추가

### DIFF
--- a/src/main/java/back/kalender/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/back/kalender/domain/schedule/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -15,6 +16,19 @@ import java.util.Optional;
 public class ScheduleController implements ScheduleControllerSpec {
 
     private final ScheduleService scheduleService;
+
+    @GetMapping("/by-artists")
+    public ResponseEntity<FollowingSchedulesListResponse> getSchedulesByArtists(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(required = false) Long artistId,
+            @RequestParam List<Long> artistIds
+    ) {
+        FollowingSchedulesListResponse response =
+                scheduleService.getSchedulesByArtistIds(year, month, artistIds, artistId);
+
+        return ResponseEntity.ok(response);
+    }
 
     @Override
     @GetMapping("/following")

--- a/src/main/java/back/kalender/global/security/SecurityConfig.java
+++ b/src/main/java/back/kalender/global/security/SecurityConfig.java
@@ -107,8 +107,8 @@ public class SecurityConfig {
                 "/api/v1/auth/email/send",
                 "/api/v1/auth/email/verify",
                 "/api/v1/user",                    // 회원가입
-                "/api/v1/schedule/**",      // 공개 일정 조회
-                "/api/v1/artist/**",               // 아티스트 정보 조회
+                "/api/v1/schedule/by-artists",      //비회원 공개 일정 조회
+                "/api/v1/artist",               //비회원 아티스트 정보 조회
                 "/favicon.ico",
                 "/swagger-ui/**",                  // Swagger UI
                 "/v3/api-docs/**",                 // OpenAPI 문서


### PR DESCRIPTION
# 🔀 Pull Request
[BE/feat] 비회원 아티스트 기반 스케줄 조회 API 추가

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #174 번호

## 📝 개요(Summary)

비회원(로그인 X) 사용자를 위한  
**팔로우 아티스트 기반 스케줄 조회 API**를 추가했습니다.

## 🔧 코드 설명 & 변경 이유(Code Description)

- 비회원의 로컬스토리지 `artistIds`를 기반으로 스케줄을 조회하는 서비스 로직 추가
- 기존 회원용 스케줄 조회 로직은 유지하고, 공통 조회/매핑 로직을 재사용
- `GET + @RequestParam` 방식으로 월 단위 스케줄 조회 구현

## 🧪 테스트 절차(Test Plan)

- Postman을 통해 비회원 `/schedule/by-artists` API 테스트 완료
- 회원 `/schedule/following` API와 응답 구조 동일함을 확인

## 🔄 API 변경 / 흐름 영향(API & Flow Impact)

- 신규 API 추가: `GET /api/v1/schedule/by-artists`
- 기존 회원 스케줄 조회 흐름에는 영향 없음

## 👀 리뷰 포인트(Notes for Reviewer)

- 비회원/회원 스케줄 조회 로직 분리 구조 확인 부탁드립니다

