### PR TITLE
[BE/feat] 공연 포스터 이미지 분리 및 초기 데이터 반영

### DIFF
--- a/src/main/java/back/kalender/global/initData/performance/PerformanceBaseInitData.java
+++ b/src/main/java/back/kalender/global/initData/performance/PerformanceBaseInitData.java
@@ -34,12 +34,12 @@ public class PerformanceBaseInitData implements ApplicationRunner {
     private final PerformanceScheduleRepository performanceScheduleRepository;
     private final ScheduleRepository scheduleRepository;
 
-    // 🎯 대상 아티스트
+    //  대상 아티스트
     private static final Set<String> TARGET = Set.of(
-            "BTS", "G-DRAGON", "aespa", "fromis_9", "NCT", "NCT WISH"
+            "BTS", "G-DRAGON", "aespa", "fromis_9" , "NCT WISH"
     );
 
-    // 🖼 공연 포스터 전용 URL (Artist 이미지 ❌)
+    //  공연 포스터 전용 URL (Artist 이미지 X)
     private static final Map<String, String> PERFORMANCE_POSTER_URL = Map.of(
             "aespa", "https://wya-kalendar-poster-images-v1.s3.ap-northeast-2.amazonaws.com/aespa.png",
             "BTS", "https://wya-kalendar-poster-images-v1.s3.ap-northeast-2.amazonaws.com/bts.png",
@@ -48,10 +48,10 @@ public class PerformanceBaseInitData implements ApplicationRunner {
             "NCT WISH", "https://wya-kalendar-poster-images-v1.s3.ap-northeast-2.amazonaws.com/nctwish.png"
     );
 
-    // 📅 예매 시작 기준일
+    //  예매 시작 기준일
     private static final LocalDate BOOKING_BASE_DATE = LocalDate.of(2026, 1, 7);
 
-    // 🎤 공연 날짜 범위
+    //  공연 날짜 범위
     private static final LocalDate PERFORMANCE_START_DATE = LocalDate.of(2026, 1, 15);
     private static final LocalDate PERFORMANCE_END_DATE   = LocalDate.of(2026, 1, 31);
 
@@ -74,11 +74,11 @@ public class PerformanceBaseInitData implements ApplicationRunner {
 
     private void createPerformance(Artist artist, int index) {
 
-        // ⏰ 예매 시작일: 1/7, 1/9, 1/11, 1/13, 1/15 ...
+        //  예매 시작일: 1/7, 1/9, 1/11, 1/13, 1/15 ...
         LocalDate bookingStartDate =
                 BOOKING_BASE_DATE.plusDays(index * 2);
 
-        // 🎲 공연일 랜덤 (1/15 ~ 1/31)
+        //  공연일 랜덤 (1/15 ~ 1/31)
         int range = (int)(
                 PERFORMANCE_END_DATE.toEpochDay()
                         - PERFORMANCE_START_DATE.toEpochDay()
@@ -88,7 +88,7 @@ public class PerformanceBaseInitData implements ApplicationRunner {
         LocalDate performanceDate =
                 PERFORMANCE_START_DATE.plusDays((int) (Math.random() * range));
 
-        // 🎯 공연 포스터 URL
+        //  공연 포스터 URL
         String posterUrl = PERFORMANCE_POSTER_URL.get(artist.getName());
         Objects.requireNonNull(posterUrl, "공연 포스터 URL 누락: " + artist.getName());
 
@@ -107,7 +107,7 @@ public class PerformanceBaseInitData implements ApplicationRunner {
                         .build()
         );
 
-        // 📅 캘린더 Schedule (CONCERT)
+        //  캘린더 Schedule (CONCERT)
         scheduleRepository.save(
                 Schedule.builder()
                         .artistId(artist.getId())
@@ -119,7 +119,7 @@ public class PerformanceBaseInitData implements ApplicationRunner {
                         .build()
         );
 
-        // 🎶 회차 2개 생성
+        //  회차 2개 생성
         createSchedule(performance, performanceDate, 1, LocalTime.of(18, 0));
         createSchedule(performance, performanceDate, 2, LocalTime.of(20, 30));
     }


### PR DESCRIPTION
# 🔀 Pull Request
<!-- PR 제목 컨벤션 -> [BE/feat] pr 제목 -->
[BE/feat] 공연 포스터 이미지 분리 및 초기 데이터 반영

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #204 번호

## 📝 개요(Summary)

공연 포스터 이미지를 아티스트 이미지와 분리하여  
`Performance` 전용 포스터 URL을 사용하도록 초기 데이터를 수정했습니다.

## 🔧 코드 설명 & 변경 이유(Code Description)

- `PerformanceBaseInitData`에서 공연 생성 시  
  `artist.getImageUrl()`을 사용하던 로직을 제거
- 아티스트 이름 기준으로 **공연 포스터 전용 S3 URL을 매핑**하여  
  `Performance.posterImageUrl`에 저장하도록 변경
- 아티스트 이미지와 공연 포스터의 역할을 명확히 분리해  
  추후 동일 아티스트의 다중 공연/포스터 변경에 대응 가능하도록 설계

## 🧪 테스트 절차(Test Plan)

- dev/prod 프로파일에서 서버 기동
- 공연 초기 데이터 생성 여부 확인
- 공연 상세 / 공연 목록 조회 시 포스터 이미지 URL 정상 노출 확인

## 🔄 API 변경 / 흐름 영향(API & Flow Impact)

- API 스펙 변경 없음
- 공연 조회 시 내려주는 `posterImageUrl` 값만 변경됨
- 기존 프론트 로직 영향 없음 (필드 동일)

## 👀 리뷰 포인트(Notes for Reviewer)

- 공연 포스터 URL 매핑 키가 `Artist.name`과 정확히 일치하는지 확인 부탁드립니다
- 추후 공연별 포스터가 달라질 경우 구조적으로 문제없는지 봐주세요
