### PR TITLE
[BE/fix] 브라우저 재접속 시 예매 초기화 및 409 에러 해결

### DIFF
--- a/src/main/java/back/kalender/domain/booking/reservation/repository/ReservationRepository.java
+++ b/src/main/java/back/kalender/domain/booking/reservation/repository/ReservationRepository.java
@@ -37,4 +37,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("now") LocalDateTime now,
             Pageable pageable
     );
+
+    // 사용자 + 회차 + 상태로 예매 조회
+    List<Reservation> findByUserIdAndPerformanceScheduleIdAndStatusIn(Long userId, Long scheduleId, List<ReservationStatus> reservationStatuses);
 }

--- a/src/main/java/back/kalender/domain/booking/session/controller/BookingSessionController.java
+++ b/src/main/java/back/kalender/domain/booking/session/controller/BookingSessionController.java
@@ -1,5 +1,6 @@
 package back.kalender.domain.booking.session.controller;
 
+import back.kalender.domain.booking.reservation.service.ReservationService;
 import back.kalender.domain.booking.session.dto.request.BookingSessionCreateRequest;
 import back.kalender.domain.booking.session.dto.response.BookingSessionCreateResponse;
 import back.kalender.domain.booking.session.service.BookingSessionService;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class BookingSessionController implements BookingSessionControllerSpec {
     private final BookingSessionService bookingSessionService;
-
+    private final ReservationService reservationService;
 
     @PostMapping("/create")
     @Override
@@ -49,9 +50,13 @@ public class BookingSessionController implements BookingSessionControllerSpec {
     @Override
     public ResponseEntity<Void> leave(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-BOOKING-SESSION-ID") String bookingSessionId
+            @RequestHeader("X-BOOKING-SESSION-ID") String bookingSessionId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        Long userId = userDetails.getUserId();
+        reservationService.cancelActiveReservationIfExists(userId, scheduleId);
         bookingSessionService.leaveActive(scheduleId, bookingSessionId);
-        return ResponseEntity.ok().build();
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/back/kalender/domain/booking/session/controller/BookingSessionControllerSpec.java
+++ b/src/main/java/back/kalender/domain/booking/session/controller/BookingSessionControllerSpec.java
@@ -286,7 +286,8 @@ public interface BookingSessionControllerSpec {
                     required = true,
                     example = "bs_abc123def456"
             )
-            @RequestHeader("X-BOOKING-SESSION-ID") String bookingSessionId
+            @RequestHeader("X-BOOKING-SESSION-ID") String bookingSessionId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }
 


### PR DESCRIPTION
# 🔀 Pull Request
[BE/fix] 브라우저 재접속 시 예매 초기화 및 409 에러 해결

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #236 


## 📝 개요(Summary)
브라우저 닫기 또는 재접속 시 발생하던 409 Conflict (ACTIVE_RESERVATION_EXISTS) 에러를 해결했습니다.

**핵심 변경사항**
- 정책 변경: "브라우저 닫기 = 예매 포기"로 명확화
- 자동 정리: 기존 활성 예매 자동 취소 및 좌석 해제
- 순서 보장: 예매 취소 → 세션 삭제 순서 강제


## 🔧 코드 설명 & 변경 이유(Code Description)

### ReservationService.cancelActiveReservationIfExists() 추가
기존 활성 예매(PENDING/HOLD)를 찾아서 완전히 정리하는 메서드 추가
```java
@Transactional
public void cancelActiveReservationIfExists(Long userId, Long scheduleId) {
    // 1. 활성 예매 조회 (PENDING, HOLD)
    List<Reservation> activeReservations = reservationRepository
            .findByUserIdAndPerformanceScheduleIdAndStatusIn(
                    userId,
                    scheduleId,
                    ReservationStatus.activeStatuses() // [PENDING, HOLD]
            );

    if (activeReservations.isEmpty()) {
        return;
    }

    Reservation reservation = activeReservations.get(0);

    // 2. HOLD된 좌석 조회
    List<ReservationSeat> reservationSeats =
            reservationSeatRepository.findByReservationId(reservation.getId());

    // 3. 좌석 상태 복구 (HOLD → AVAILABLE)
    List<Long> performanceSeatIds = reservationSeats.stream()
            .map(ReservationSeat::getPerformanceSeatId)
            .toList();

    List<PerformanceSeat> seats = performanceSeatRepository.findAllById(performanceSeatIds);
    for (PerformanceSeat seat : seats) {
        if (seat.getStatus() == SeatStatus.HOLD) {
            seat.updateStatus(SeatStatus.AVAILABLE);
            seat.clearHoldInfo();
        }
    }
    performanceSeatRepository.saveAll(seats);

    // 4. ReservationSeat 삭제
    reservationSeatRepository.deleteByReservationId(reservation.getId());

    // 5. 예매 취소
    reservation.cancel(); // status = CANCELLED
    reservationRepository.save(reservation);

    // 6. Redis 정리 이벤트 발행 (TransactionalEventListener)
    for (Long seatId : performanceSeatIds) {
        eventPublisher.publishEvent(
                new SeatReleaseCompletedEvent(scheduleId, seatId, userId, SeatStatus.AVAILABLE)
        );
    }
}
```

**처리 내용:**
✅ DB: PerformanceSeat (HOLD → AVAILABLE)
✅ DB: ReservationSeat (삭제)
✅ DB: Reservation (CANCELLED)
✅ Redis: seat:hold:owner:{scheduleId}:{seatId} (이벤트로 삭제)

### ActiveSweepScheduler 수정
60초 무응답 세션 자동 정리 시 예매도 함께 취소

### ReservationService.createReservation() 자동 취소 추가
세션 생성 시 정리가 안 됐더라도, 예매 생성 시점에 자동으로 기존 예매 취소

**다층 방어:**
1차: leave() API에서 명시적 취소
2차: ActiveSweepScheduler에서 자동 취소
3차: createReservation()에서 최종 확인 및 자동 취소

### BookingSessionService.checkExistingSession() 정책 변경
```java
// 변경 후: 무조건 삭제 후 재생성
private String checkExistingSession(
        Long userId,
        Long scheduleId,
        String deviceId
) {
    String mappingKey = BOOKING_SESSION_KEY_PREFIX + userId + ":" + scheduleId;
    String existingSessionId = redisTemplate.opsForValue().get(mappingKey);

    if (existingSessionId == null) {
        return null;
    }

    log.info("[BookingSession] 기존 세션 발견, 무조건 삭제 후 재생성 - sessionId={}",
            existingSessionId);

    // Active 여부 상관없이 삭제
    deleteBookingSessionBySessionId(existingSessionId);

    return null; // 새로 생성
}
```

**변경 이유:**
기존: Active 확인 → 있으면 재사용, 없으면 삭제
변경: 무조건 삭제 후 재생성
의도: "브라우저 닫기 = 예매 포기" 정책 명확화


## 🧪 테스트 절차(Test Plan)
### Postman 수동 테스트
### 시나리오 1: 정상 플로우
```
1. 대기열 진입 (qsid 발급)
2. ADMITTED 상태 확인 (waitingToken 획득)
3. BookingSession 생성
4. Reservation 생성 → 201 OK
5. 좌석 HOLD → 200 OK
6. leave API 호출 → 204 No Content
7. 재접속 (새 대기열 진입)
8. 새 BookingSession 생성
9. 새 Reservation 생성 → ✅ 201 OK (409 아님!)
10. 같은 좌석 다시 HOLD → 200 OK
```

### 시나리오 2: Active 만료 후 재접속
```
1-5. 위와 동일
6. 브라우저 닫기 (leave API 호출 X)
7. 70초 대기 (ActiveSweepScheduler 동작)
8-10. 재접속 → ✅ 409 없이 정상 동작
```
### 시나리오 3: 409 에러 수동 해결
```
1. 409 에러 발생 (테스트 환경)
2. leave API 호출
3. 페이지 새로고침
4. ✅ 정상 동작
```

### BookingSessionServiceTest 수정 
변경사항:
❌ 삭제: checkExistingSession_ActiveSession_Reuse 테스트
❌ 삭제: checkExistingSession_InactiveSession_DeleteAndCreate 테스트
✅ 추가: createWithWaitingToken_AlwaysDeleteAndRecreate 테스트

## 🔄 API 변경 / 흐름 영향(API & Flow Impact)

<!-- API 스펙 변경 또는 기존 흐름에 영향이 있는 경우 **필수로 작성** -->


## 👀 리뷰 포인트(Notes for Reviewer)

<!-- 리뷰어에게 특별히 확인받고 싶은 내용을 작성  -->

