### PR TITLE
**[BE/feat] 좌석 조회 API 분리(블록/서브블록/상세) + 집계 쿼리 적용으로 성능 개선**

### DIFF
--- a/src/main/java/back/kalender/domain/booking/performanceSeat/controller/PerformanceSeatStructureController.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/controller/PerformanceSeatStructureController.java
@@ -1,0 +1,48 @@
+package back.kalender.domain.booking.performanceSeat.controller;
+
+import back.kalender.domain.booking.performanceSeat.dto.BlockSummaryResponse;
+import back.kalender.domain.booking.performanceSeat.dto.SeatDetailResponse;
+import back.kalender.domain.booking.performanceSeat.dto.SubBlockSummaryResponse;
+import back.kalender.domain.booking.performanceSeat.service.PerformanceSeatQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/performances")
+public class PerformanceSeatStructureController {
+
+    private final PerformanceSeatQueryService performanceSeatQueryService;
+
+    // 1) 블록 요약
+    @GetMapping("/{scheduleId}/seats/summary")
+    public List<BlockSummaryResponse> getBlockSummaries(
+            @PathVariable Long scheduleId,
+            @RequestHeader(value = "X-BOOKING-SESSION-ID", required = false) String bookingSessionId
+    ) {
+        return performanceSeatQueryService.getBlockSummaries(scheduleId, bookingSessionId);
+    }
+
+    // 2) 서브블록 요약
+    @GetMapping("/{scheduleId}/seats/blocks/{block}/sub-blocks")
+    public List<SubBlockSummaryResponse> getSubBlockSummaries(
+            @PathVariable Long scheduleId,
+            @PathVariable String block,
+            @RequestHeader(value = "X-BOOKING-SESSION-ID", required = false) String bookingSessionId
+    ) {
+        return performanceSeatQueryService.getSubBlockSummaries(scheduleId, block, bookingSessionId);
+    }
+
+    // 3) 좌석 상세
+    @GetMapping("/{scheduleId}/seats/blocks/{block}/sub-blocks/{subBlock}")
+    public List<SeatDetailResponse> getSeatDetails(
+            @PathVariable Long scheduleId,
+            @PathVariable String block,
+            @PathVariable String subBlock,
+            @RequestHeader(value = "X-BOOKING-SESSION-ID", required = false) String bookingSessionId
+    ) {
+        return performanceSeatQueryService.getSeatDetails(scheduleId, block, subBlock, bookingSessionId);
+    }
+}

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/dto/BlockSummaryResponse.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/dto/BlockSummaryResponse.java
@@ -1,0 +1,17 @@
+package back.kalender.domain.booking.performanceSeat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BlockSummaryResponse {
+    private final int floor;
+    private final String block;
+    private final long totalSeats;
+    private final long availableSeats;
+
+    public static BlockSummaryResponse of(int floor, String block, long total, long available) {
+        return new BlockSummaryResponse(floor, block, total, available);
+    }
+}

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/dto/SeatDetailResponse.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/dto/SeatDetailResponse.java
@@ -1,0 +1,17 @@
+package back.kalender.domain.booking.performanceSeat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SeatDetailResponse {
+    private final Long seatId;
+    private final int rowNumber;
+    private final int seatNumber;
+    private final Long priceGradeId;
+
+    public static SeatDetailResponse of(Long seatId, int rowNumber, int seatNumber, Long priceGradeId) {
+        return new SeatDetailResponse(seatId, rowNumber, seatNumber, priceGradeId);
+    }
+}

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/dto/SubBlockSummaryResponse.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/dto/SubBlockSummaryResponse.java
@@ -1,0 +1,16 @@
+package back.kalender.domain.booking.performanceSeat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubBlockSummaryResponse {
+    private final String subBlock;
+    private final long total;
+    private final long available;
+
+    public static SubBlockSummaryResponse of(String subBlock, long total, long available) {
+        return new SubBlockSummaryResponse(subBlock, total, available);
+    }
+}

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/repository/PerformanceSeatRepository.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/repository/PerformanceSeatRepository.java
@@ -1,6 +1,5 @@
 package back.kalender.domain.booking.performanceSeat.repository;
 
-import back.kalender.domain.booking.performanceSeat.dto.PerformanceSeatResponse;
 import back.kalender.domain.booking.performanceSeat.entity.PerformanceSeat;
 import back.kalender.domain.booking.performanceSeat.entity.SeatStatus;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +13,7 @@ import java.util.Optional;
 
 public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat, Long> {
 
+    // ---- 기존 ----
     List<PerformanceSeat> findAllByScheduleId(Long scheduleId);
 
     Optional<PerformanceSeat> findByIdAndScheduleId(Long id, Long scheduleId);
@@ -31,4 +31,127 @@ public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat
             @Param("now") LocalDateTime now,
             Pageable pageable
     );
+
+    // =========================
+    // 추가: 블록/서브블록 집계 + 상세 조회 (성능용)
+    // =========================
+
+    // 1) 블록별 총 좌석 수
+    @Query("""
+        select p.floor as floor, p.block as block, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+        group by p.floor, p.block
+    """)
+    List<BlockCountView> countTotalByBlock(@Param("scheduleId") Long scheduleId);
+
+    // 1-2) 블록별 DB 기준 "AVAILABLE" 좌석 수 (Redis 반영 전)
+    @Query("""
+        select p.floor as floor, p.block as block, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.status = :availableStatus
+        group by p.floor, p.block
+    """)
+    List<BlockCountView> countDbAvailableByBlock(
+            @Param("scheduleId") Long scheduleId,
+            @Param("availableStatus") SeatStatus availableStatus
+    );
+
+    // 1-3) 블록별 "override 차감"용: (Redis SOLD/HOLD에 걸린 좌석 중) DB에서 AVAILABLE로 잡힌 개수
+    @Query("""
+        select p.floor as floor, p.block as block, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.status = :availableStatus
+          and p.id in :seatIds
+        group by p.floor, p.block
+    """)
+    List<BlockCountView> countDbAvailableOverridesByBlock(
+            @Param("scheduleId") Long scheduleId,
+            @Param("availableStatus") SeatStatus availableStatus,
+            @Param("seatIds") List<Long> seatIds
+    );
+
+    // 2) 서브블록별 총 좌석 수
+    @Query("""
+        select p.subBlock as subBlock, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.block = :block
+        group by p.subBlock
+    """)
+    List<SubBlockCountView> countTotalBySubBlock(
+            @Param("scheduleId") Long scheduleId,
+            @Param("block") String block
+    );
+
+    // 2-2) 서브블록별 DB 기준 AVAILABLE 수
+    @Query("""
+        select p.subBlock as subBlock, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.block = :block
+          and p.status = :availableStatus
+        group by p.subBlock
+    """)
+    List<SubBlockCountView> countDbAvailableBySubBlock(
+            @Param("scheduleId") Long scheduleId,
+            @Param("block") String block,
+            @Param("availableStatus") SeatStatus availableStatus
+    );
+
+    // 2-3) 서브블록별 override 차감용
+    @Query("""
+        select p.subBlock as subBlock, count(p) as cnt
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.block = :block
+          and p.status = :availableStatus
+          and p.id in :seatIds
+        group by p.subBlock
+    """)
+    List<SubBlockCountView> countDbAvailableOverridesBySubBlock(
+            @Param("scheduleId") Long scheduleId,
+            @Param("block") String block,
+            @Param("availableStatus") SeatStatus availableStatus,
+            @Param("seatIds") List<Long> seatIds
+    );
+
+    // 3) 상세 조회 (해당 subBlock 좌석만) - 엔티티 전체 로딩 대신 Projection
+    @Query("""
+        select p.id as seatId,
+               p.rowNumber as rowNumber,
+               p.seatNumber as seatNumber,
+               p.priceGradeId as priceGradeId
+        from PerformanceSeat p
+        where p.scheduleId = :scheduleId
+          and p.block = :block
+          and p.subBlock = :subBlock
+        order by p.rowNumber asc, p.seatNumber asc
+    """)
+    List<SeatDetailView> findSeatDetails(
+            @Param("scheduleId") Long scheduleId,
+            @Param("block") String block,
+            @Param("subBlock") String subBlock
+    );
+
+    // ----- Projection interfaces -----
+    interface BlockCountView {
+        int getFloor();
+        String getBlock();
+        long getCnt();
+    }
+
+    interface SubBlockCountView {
+        String getSubBlock();
+        long getCnt();
+    }
+
+    interface SeatDetailView {
+        Long getSeatId();
+        int getRowNumber();
+        int getSeatNumber();
+        Long getPriceGradeId();
+    }
 }

--- a/src/main/java/back/kalender/domain/booking/performanceSeat/service/PerformanceSeatQueryService.java
+++ b/src/main/java/back/kalender/domain/booking/performanceSeat/service/PerformanceSeatQueryService.java
@@ -1,18 +1,19 @@
 package back.kalender.domain.booking.performanceSeat.service;
 
+import back.kalender.domain.booking.performanceSeat.dto.BlockSummaryResponse;
 import back.kalender.domain.booking.performanceSeat.dto.PerformanceSeatResponse;
+import back.kalender.domain.booking.performanceSeat.dto.SeatDetailResponse;
+import back.kalender.domain.booking.performanceSeat.dto.SubBlockSummaryResponse;
 import back.kalender.domain.booking.performanceSeat.entity.SeatStatus;
 import back.kalender.domain.booking.performanceSeat.repository.PerformanceSeatRepository;
 import back.kalender.domain.booking.waitingRoom.service.QueueAccessService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -25,79 +26,249 @@ public class PerformanceSeatQueryService {
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final String SEAT_SOLD_SET_KEY = "seat:sold:%d";
-    private static final String SEAT_HOLD_OWNER_KEY = "seat:hold:owner:%d:%d";
+    private static final String SEAT_HOLD_OWNER_KEY_PATTERN = "seat:hold:owner:%d:*";
 
-//    @Cacheable(
-//            cacheNames = "seatLayout",
-//            key = "#scheduleId"
-//    )
+    private static final int IN_CLAUSE_CHUNK_SIZE = 1000;
+
+    // =========================================================
+    // (기존) 전체 좌석 조회 API - 기존 컨트롤러가 사용 (그대로 둬도 됨)
+    // =========================================================
     @Transactional(readOnly = true)
-    public List<PerformanceSeatResponse> getSeatsByScheduleId(
-        Long scheduleId,
-        String bookingSessionId
-    ) {
-        // 1. Active 상태 체크
+    public List<PerformanceSeatResponse> getSeatsByScheduleId(Long scheduleId, String bookingSessionId) {
         queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
 
-        // 2. Redis SOLD set 조회
-        String soldSetKey = String.format(SEAT_SOLD_SET_KEY, scheduleId);
-        Set<String> soldSeatIdsStr = redisTemplate.opsForSet().members(soldSetKey);
+        Set<Long> soldSeatIds = loadSoldSeatIds(scheduleId);
+        Set<Long> heldSeatIds = loadHeldSeatIds(scheduleId);
 
-        Set<Long> soldSeatIds = soldSeatIdsStr == null ? Set.of()
-                : soldSeatIdsStr.stream()
-                .map(Long::parseLong)
-                .collect(Collectors.toSet());
-
-        log.debug("[SeatQuery] Redis SOLD 좌석 수 - scheduleId={}, count={}",
-                scheduleId, soldSeatIds.size());
-
-        // 3. Redis HOLD owner 키 패턴 조회
-        String holdPattern = String.format("seat:hold:owner:%d:*", scheduleId);
-        Set<String> holdKeys = redisTemplate.keys(holdPattern);
-
-        Set<Long> heldSeatIds = holdKeys == null ? Set.of()
-                : holdKeys.stream()
-                .map(key -> {
-                    String[] parts = key.split(":");
-                    return Long.parseLong(parts[4]); // seat:hold:owner:{scheduleId}:{seatId}
-                })
-                .collect(Collectors.toSet());
-
-        log.debug("[SeatQuery] Redis HOLD 좌석 수 - scheduleId={}, count={}",
-                scheduleId, heldSeatIds.size());
-
-        // 4. DB 조회 + Redis 상태 우선 적용
         return performanceSeatRepository.findAllByScheduleId(scheduleId)
                 .stream()
                 .map(seat -> {
                     SeatStatus finalStatus;
 
-                    // Redis 우선 체크 (Redis가 Source of Truth)
                     if (soldSeatIds.contains(seat.getId())) {
                         finalStatus = SeatStatus.SOLD;
-
-                        // DB와 다르면 로그 (디버깅용)
-                        if (seat.getStatus() != SeatStatus.SOLD) {
-                            log.warn("[SeatQuery] DB-Redis 불일치(SOLD) - seatId={}, DB={}, Redis=SOLD",
-                                    seat.getId(), seat.getStatus());
-                        }
-
                     } else if (heldSeatIds.contains(seat.getId())) {
                         finalStatus = SeatStatus.HOLD;
-
-                        // DB와 다르면 로그
-                        if (seat.getStatus() != SeatStatus.HOLD) {
-                            log.warn("[SeatQuery] DB-Redis 불일치(HOLD) - seatId={}, DB={}, Redis=HOLD",
-                                    seat.getId(), seat.getStatus());
-                        }
-
                     } else {
-                        // Redis에 없으면 DB 상태 사용
                         finalStatus = seat.getStatus();
                     }
 
                     return PerformanceSeatResponse.from(seat, finalStatus);
                 })
                 .toList();
+    }
+
+    // =========================================================
+    // 1) 블록 요약 (DB 집계 + Redis SoT 반영)
+    // =========================================================
+    @Transactional(readOnly = true)
+    public List<BlockSummaryResponse> getBlockSummaries(Long scheduleId, String bookingSessionId) {
+        queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
+
+        SeatStatus availableStatus = resolveAvailableStatus();
+
+        // DB 집계
+        List<PerformanceSeatRepository.BlockCountView> totals =
+                performanceSeatRepository.countTotalByBlock(scheduleId);
+
+        List<PerformanceSeatRepository.BlockCountView> dbAvailables =
+                performanceSeatRepository.countDbAvailableByBlock(scheduleId, availableStatus);
+
+        // Redis SoT (sold + hold) 좌석 id
+        Set<Long> overrideIds = new HashSet<>();
+        overrideIds.addAll(loadSoldSeatIds(scheduleId));
+        overrideIds.addAll(loadHeldSeatIds(scheduleId));
+
+        // overrideIds 중 "DB에서 AVAILABLE로 잡힌 좌석"이 있으면 DB available에서 차감해야 함
+        Map<String, Long> overrideAvailableCountByBlock =
+                countDbAvailableOverridesByBlockChunked(scheduleId, availableStatus, overrideIds);
+
+        Map<String, Long> dbAvailableCountByBlock = dbAvailables.stream()
+                .collect(Collectors.toMap(
+                        v -> blockKey(v.getFloor(), v.getBlock()),
+                        PerformanceSeatRepository.BlockCountView::getCnt
+                ));
+
+        return totals.stream()
+                .map(v -> {
+                    String key = blockKey(v.getFloor(), v.getBlock());
+                    long total = v.getCnt();
+                    long dbAvailable = dbAvailableCountByBlock.getOrDefault(key, 0L);
+                    long overrideAvailable = overrideAvailableCountByBlock.getOrDefault(key, 0L);
+
+                    long finalAvailable = Math.max(0L, dbAvailable - overrideAvailable);
+
+                    return BlockSummaryResponse.of(v.getFloor(), v.getBlock(), total, finalAvailable);
+                })
+                .sorted(Comparator.comparing(BlockSummaryResponse::getFloor)
+                        .thenComparing(BlockSummaryResponse::getBlock))
+                .toList();
+    }
+
+    // =========================================================
+    // 2) 서브블록 요약 (DB 집계 + Redis SoT 반영)
+    // =========================================================
+    @Transactional(readOnly = true)
+    public List<SubBlockSummaryResponse> getSubBlockSummaries(Long scheduleId, String block, String bookingSessionId) {
+        queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
+
+        SeatStatus availableStatus = resolveAvailableStatus();
+
+        // DB 집계
+        List<PerformanceSeatRepository.SubBlockCountView> totals =
+                performanceSeatRepository.countTotalBySubBlock(scheduleId, block);
+
+        List<PerformanceSeatRepository.SubBlockCountView> dbAvailables =
+                performanceSeatRepository.countDbAvailableBySubBlock(scheduleId, block, availableStatus);
+
+        // Redis SoT seat ids
+        Set<Long> overrideIds = new HashSet<>();
+        overrideIds.addAll(loadSoldSeatIds(scheduleId));
+        overrideIds.addAll(loadHeldSeatIds(scheduleId));
+
+        Map<String, Long> overrideAvailableCountBySubBlock =
+                countDbAvailableOverridesBySubBlockChunked(scheduleId, block, availableStatus, overrideIds);
+
+        Map<String, Long> dbAvailableCountBySubBlock = dbAvailables.stream()
+                .collect(Collectors.toMap(
+                        PerformanceSeatRepository.SubBlockCountView::getSubBlock,
+                        PerformanceSeatRepository.SubBlockCountView::getCnt
+                ));
+
+        return totals.stream()
+                .map(v -> {
+                    String subBlock = v.getSubBlock();
+                    long total = v.getCnt();
+                    long dbAvailable = dbAvailableCountBySubBlock.getOrDefault(subBlock, 0L);
+                    long overrideAvailable = overrideAvailableCountBySubBlock.getOrDefault(subBlock, 0L);
+
+                    long finalAvailable = Math.max(0L, dbAvailable - overrideAvailable);
+
+                    return SubBlockSummaryResponse.of(subBlock, total, finalAvailable);
+                })
+                .sorted(Comparator.comparing(SubBlockSummaryResponse::getSubBlock))
+                .toList();
+    }
+
+    // =========================================================
+    // 3) 좌석 상세 (필요한 subBlock만 DB에서 조회)
+    // =========================================================
+    @Transactional(readOnly = true)
+    public List<SeatDetailResponse> getSeatDetails(Long scheduleId, String block, String subBlock, String bookingSessionId) {
+        queueAccessService.checkSeatAccess(scheduleId, bookingSessionId);
+
+        return performanceSeatRepository.findSeatDetails(scheduleId, block, subBlock)
+                .stream()
+                .map(v -> SeatDetailResponse.of(
+                        v.getSeatId(),
+                        v.getRowNumber(),
+                        v.getSeatNumber(),
+                        v.getPriceGradeId()
+                ))
+                .toList();
+    }
+
+    // ---------------------------
+    // Redis helpers
+    // ---------------------------
+    private Set<Long> loadSoldSeatIds(Long scheduleId) {
+        String soldSetKey = String.format(SEAT_SOLD_SET_KEY, scheduleId);
+        Set<String> soldSeatIdsStr = redisTemplate.opsForSet().members(soldSetKey);
+
+        if (soldSeatIdsStr == null || soldSeatIdsStr.isEmpty()) return Set.of();
+
+        Set<Long> result = soldSeatIdsStr.stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+
+        log.debug("[SeatQuery] Redis SOLD 좌석 수 - scheduleId={}, count={}", scheduleId, result.size());
+        return result;
+    }
+
+    private Set<Long> loadHeldSeatIds(Long scheduleId) {
+        String holdPattern = String.format(SEAT_HOLD_OWNER_KEY_PATTERN, scheduleId);
+        Set<String> holdKeys = redisTemplate.keys(holdPattern);
+
+        if (holdKeys == null || holdKeys.isEmpty()) return Set.of();
+
+        Set<Long> result = holdKeys.stream()
+                .map(key -> {
+                    String[] parts = key.split(":");
+                    return Long.parseLong(parts[4]); // seat:hold:owner:{scheduleId}:{seatId}
+                })
+                .collect(Collectors.toSet());
+
+        log.debug("[SeatQuery] Redis HOLD 좌석 수 - scheduleId={}, count={}", scheduleId, result.size());
+        return result;
+    }
+
+    // ---------------------------
+    // override 집계 (IN 절 chunk)
+    // ---------------------------
+    private Map<String, Long> countDbAvailableOverridesByBlockChunked(
+            Long scheduleId,
+            SeatStatus availableStatus,
+            Set<Long> overrideIds
+    ) {
+        if (overrideIds == null || overrideIds.isEmpty()) return Map.of();
+
+        List<Long> ids = new ArrayList<>(overrideIds);
+        Map<String, Long> acc = new HashMap<>();
+
+        for (int i = 0; i < ids.size(); i += IN_CLAUSE_CHUNK_SIZE) {
+            List<Long> chunk = ids.subList(i, Math.min(i + IN_CLAUSE_CHUNK_SIZE, ids.size()));
+            List<PerformanceSeatRepository.BlockCountView> rows =
+                    performanceSeatRepository.countDbAvailableOverridesByBlock(scheduleId, availableStatus, chunk);
+
+            for (var r : rows) {
+                String key = blockKey(r.getFloor(), r.getBlock());
+                acc.merge(key, r.getCnt(), Long::sum);
+            }
+        }
+        return acc;
+    }
+
+    private Map<String, Long> countDbAvailableOverridesBySubBlockChunked(
+            Long scheduleId,
+            String block,
+            SeatStatus availableStatus,
+            Set<Long> overrideIds
+    ) {
+        if (overrideIds == null || overrideIds.isEmpty()) return Map.of();
+
+        List<Long> ids = new ArrayList<>(overrideIds);
+        Map<String, Long> acc = new HashMap<>();
+
+        for (int i = 0; i < ids.size(); i += IN_CLAUSE_CHUNK_SIZE) {
+            List<Long> chunk = ids.subList(i, Math.min(i + IN_CLAUSE_CHUNK_SIZE, ids.size()));
+            List<PerformanceSeatRepository.SubBlockCountView> rows =
+                    performanceSeatRepository.countDbAvailableOverridesBySubBlock(scheduleId, block, availableStatus, chunk);
+
+            for (var r : rows) {
+                acc.merge(r.getSubBlock(), r.getCnt(), Long::sum);
+            }
+        }
+        return acc;
+    }
+
+    private String blockKey(int floor, String block) {
+        return floor + "|" + block;
+    }
+
+    /**
+     * 프로젝트 SeatStatus 값에 맞춰 자동 선택.
+     * - AVAILABLE 있으면 AVAILABLE
+     * - 없으면 OPEN 시도
+     */
+    private SeatStatus resolveAvailableStatus() {
+        try {
+            return SeatStatus.valueOf("AVAILABLE");
+        } catch (IllegalArgumentException ignored) {
+            try {
+                return SeatStatus.valueOf("OPEN");
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException("SeatStatus에 AVAILABLE/OPEN 중 하나가 필요합니다.");
+            }
+        }
     }
 }

--- a/src/main/java/back/kalender/global/security/SecurityConfig.java
+++ b/src/main/java/back/kalender/global/security/SecurityConfig.java
@@ -72,7 +72,8 @@ public class SecurityConfig {
                 "/ws-chat/**",                     // WebSocket 연결 허용
                 "/payment-test.html",               // 결제 테스트 페이지
                 "/payment/**",                      // 결제 관련 정적 파일
-                "/api/v1/payments/client-key"      // 결제 클라이언트 키 조회 (인증 불필요)
+                "/api/v1/payments/client-key",     // 결제 클라이언트 키 조회 (인증 불필요)
+                "/actuator/prometheus"
         ));
         
         // 개발 환경에서만 H2 콘솔 허용


### PR DESCRIPTION
# 🔀 Pull Request
<!-- PR 제목 컨벤션 -> [BE/feat] pr 제목 -->
**[BE/feat] 좌석 조회 API 분리(블록/서브블록/상세) + 집계 쿼리 적용으로 성능 개선**

## 🏷 PR 타입(Type)
아래에서 이번 PR의 종류를 선택해주세요.

- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (기능 변화 없는 구조 개선)
- [ ] Chore (환경 설정 / 빌드 / 기타 작업)
- [ ] Docs (문서 작업)

## 🍗 관련 이슈

- close #290


## 📝 개요(Summary)

기존 `scheduleId` 기준으로 전체 좌석(예: 15,000석)을 한 번에 내려주던 조회 방식에서,
프론트 초기 렌더/탐색 플로우에 맞게 **블록 요약 → 서브블록 요약 → 좌석 상세**로 API를 분리했습니다.

또한 요약 API는 **DB에서 group-by/count 집계 쿼리로 계산**하도록 변경하여,
대량 좌석 전체 조회/직렬화 비용을 줄이고 응답 성능을 개선했습니다.


## 🔧 코드 설명 & 변경 이유(Code Description)

### 1) 좌석 조회 API 3단 분리 추가
- `GET /api/v1/performances/{scheduleId}/seats/summary`
  - 공연장 좌석을 **floor + block 단위로 요약**(totalSeats, availableSeats)
- `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks`
  - 특정 block 클릭 시 **subBlock(A1, A2...) 요약**(total, available)
- `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks/{subBlock}`
  - 특정 subBlock 선택 시 **좌석 상세 리스트**(seatId, rowNumber, seatNumber, priceGradeId)

**변경 이유**
- 전체 좌석을 한 번에 내려주면 응답 크기/직렬화/DB 조회 비용이 커서 p95 지연이 커짐
- 프론트 UX는 “블록 선택 → 서브블록 선택 → 좌석 렌더링” 흐름이므로, API를 동일한 단계로 분리하는 것이 자연스러움

### 2) 요약 API 성능 최적화 (DB 집계)
- 블록/서브블록 요약은 `findAllByScheduleId()`로 전체 row를 읽지 않고,
  **DB에서 group-by/count 집계 쿼리로 total/available을 계산**하도록 구현했습니다.

### 3) Redis SoT 기반 상태 반영 (잔여석 정확도)
- SOLD/HOLD는 Redis가 Source of Truth이므로,
  요약(available) 계산 시 **DB에서 AVAILABLE로 잡혀있던 좌석이 Redis SOLD/HOLD면 차감**하도록 반영했습니다.
- `IN` 절이 커질 수 있어 **chunk 단위로 나눠 집계**하여 안정적으로 처리했습니다.

### 4) 기존 API/코드 영향 최소화
- 기존 좌석 전체 조회 컨트롤러/레포지토리/서비스는 유지하고,
  분리 API용 컨트롤러/DTO/레포지토리 메서드를 **추가**하여 기존 호출부 영향 없이 확장했습니다.


## 🧪 테스트 절차(Test Plan)

- [ ] (선택) 로컬에서 아래 순서로 API 호출 확인
  1. `GET /api/v1/performances/{scheduleId}/seats/summary`
  2. `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks`
  3. `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks/{subBlock}`
- [ ] (선택) Redis에 SOLD/HOLD 데이터를 넣고 잔여석(available) 차감 반영 확인
- [ ] (선택) k6로 상세 조회 API에 부하를 걸어 응답 시간(p95) 개선 여부 확인


## 🔄 API 변경 / 흐름 영향(API & Flow Impact)

### ✅ 신규 API 추가 (프론트 좌석 렌더링 플로우 변경 가능)
- **블록 요약 조회**
  - `GET /api/v1/performances/{scheduleId}/seats/summary`
  - Response: `[{ floor, block, totalSeats, availableSeats }, ...]`

- **서브블록 요약 조회**
  - `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks`
  - Response: `[{ subBlock, total, available }, ...]`

- **좌석 상세 조회**
  - `GET /api/v1/performances/{scheduleId}/seats/blocks/{block}/sub-blocks/{subBlock}`
  - Response: `[{ seatId, rowNumber, seatNumber, priceGradeId }, ...]`

### ✅ 기존 API 유지
- 기존 전체 좌석 조회 API 및 레포지토리 메서드는 유지되어 기존 호출 흐름에는 영향이 없습니다.


## 👀 리뷰 포인트(Notes for Reviewer)

- 요약 API에서 **available 계산이 Redis SOLD/HOLD를 우선 반영**하도록 되어 있으며,
  DB의 AVAILABLE 상태와 Redis 상태가 불일치할 때 차감 로직이 기대대로 동작하는지 확인 부탁드립니다.
- `IN` 절 집계는 **chunk(기본 1000)** 단위로 수행하도록 구현했는데,
  운영 데이터 규모에 따라 chunk 크기 조정이 필요할 수 있습니다.
- 프로젝트의 `SeatStatus`에서 “예매 가능” 상태가 `AVAILABLE`이 아닌 경우(예: `OPEN`)라면,
  해당 상태 매핑이 정확한지 확인이 필요합니다.
